### PR TITLE
Added support for putting the extension at the end of the generated url.

### DIFF
--- a/src/param-builder.ts
+++ b/src/param-builder.ts
@@ -75,7 +75,7 @@ export type BuildOptions = {
   /**
    * Whether to append the path in plain.
    *
-   * Defaults to false. If true, encodes the path to a  base64url
+   * Defaults to false. If false, encodes the path to a base64url
    */
   plain?: boolean;
 
@@ -167,7 +167,10 @@ class ParamBuilder {
     if (path && plain) mods.push('plain', path);
     else mods.push(encodeFilePath(path));
 
-    const extension = options?.addExtension ? this.getExtention(path) : '';
+    let extension = '';
+    if (!plain && options?.addExtension) {
+      extension = this.getExtension();
+    }
 
     const res = mods.join('/') + extension;
 
@@ -191,18 +194,11 @@ class ParamBuilder {
    * @param path The path to the target image, e.g. `https://example.com/foo.png`
    * @returns An extension if found, or an empty string
    */
-  private getExtention(path: string): string {
-    let extension = '';
-
+  private getExtension(): string {
     const formatString = this.modifiers.get('format');
-    if (formatString) {
-      extension = `.${formatString.split(':').pop()}`;
-    } else {
-      const parts = path.split('.');
-      if (parts.length) extension = `.${parts.pop()}`;
-    }
+    if (!formatString) return '';
 
-    return extension;
+    return `.${formatString.split(':').pop()}`;
   }
 
   /**

--- a/src/param-builder.ts
+++ b/src/param-builder.ts
@@ -1,9 +1,9 @@
 import adjust from './transformers/adjust.js';
 import autoRotate from './transformers/auto-rotate.js';
-import background from './transformers/background.js';
 import backgroundAlpha from './transformers/background-alpha.js';
-import blur from './transformers/blur.js';
+import background from './transformers/background.js';
 import blurDetections from './transformers/blur-detections.js';
+import blur from './transformers/blur.js';
 import brightness from './transformers/brightness.js';
 import cacheBuster from './transformers/cache-buster.js';
 import contrast from './transformers/contrast.js';
@@ -15,12 +15,12 @@ import drawDetections from './transformers/draw-detections.js';
 import enforceThumbnail from './transformers/enforce-thumbnail.js';
 import enlarge from './transformers/enlarge.js';
 import expires from './transformers/expires.js';
-import extend from './transformers/extend.js';
 import extendAspectRatio from './transformers/extend-aspect-ratio.js';
+import extend from './transformers/extend.js';
 import fallbackImageUrl from './transformers/fallback-image-url.js';
 import fileName from './transformers/filename.js';
-import format from './transformers/format.js';
 import formatQuality from './transformers/format-quality.js';
+import format from './transformers/format.js';
 import gifOptions from './transformers/gif-options.js';
 import gradient from './transformers/gradient.js';
 import gravity from './transformers/gravity.js';
@@ -49,11 +49,11 @@ import style from './transformers/style.js';
 import trim from './transformers/trim.js';
 import unsharpen from './transformers/unsharpen.js';
 import videoThumbnailSecond from './transformers/video-thumbnail-second.js';
-import watermark from './transformers/watermark.js';
 import watermarkShadow from './transformers/watermark-shadow.js';
 import watermarkSize from './transformers/watermark-size.js';
 import watermarkText from './transformers/watermark-text.js';
 import watermarkUrl from './transformers/watermark-url.js';
+import watermark from './transformers/watermark.js';
 import zoom from './transformers/zoom.js';
 
 import { encodeFilePath, generateSignature } from './common.js';
@@ -78,6 +78,13 @@ export type BuildOptions = {
    * Defaults to false. If true, encodes the path to a  base64url
    */
   plain?: boolean;
+
+  /**
+   * Whether to append the extension (or filetype) to the end of the url.
+   *
+   * Defaults to false. If true adds the extension.
+   */
+  addExtension?: boolean;
 
   /**
    * The signature to apply
@@ -160,7 +167,9 @@ class ParamBuilder {
     if (path && plain) mods.push('plain', path);
     else mods.push(encodeFilePath(path));
 
-    const res = mods.join('/');
+    const extension = options?.addExtension ? this.getExtention(path) : '';
+
+    const res = mods.join('/') + extension;
 
     // If no signature is calculated add a - as placeholder
     // See https://github.com/imgproxy/imgproxy/blob/b243a08254b9ca7da2c628429cd870c111ece5c9/docs/signing_the_url.md
@@ -174,6 +183,26 @@ class ParamBuilder {
       : `-/${res}`;
 
     return baseUrl ? `${baseUrl}/${finalPath}` : `/${finalPath}`;
+  }
+
+  /**
+   * Get the extension for the file. Checks the specified format and the target image.
+   *
+   * @param path The path to the target image, e.g. `https://example.com/foo.png`
+   * @returns An extension if found, or an empty string
+   */
+  private getExtention(path: string): string {
+    let extension = '';
+
+    const formatString = this.modifiers.get('format');
+    if (formatString) {
+      extension = `.${formatString.split(':').pop()}`;
+    } else {
+      const parts = path.split('.');
+      if (parts.length) extension = `.${parts.pop()}`;
+    }
+
+    return extension;
   }
 
   /**

--- a/test/chain.test.ts
+++ b/test/chain.test.ts
@@ -58,19 +58,6 @@ describe('Chain', () => {
     );
   });
 
-  test('Add Extension from path', () => {
-    expect(
-      pb().build({
-        path: 'test.png',
-        addExtension: true,
-        signature: {
-          key: '73757065722d7365637265742d6b6579', // super-secret-key
-          salt: '73757065722d7365637265742d73616c74', // super-secret-salt
-        },
-      }),
-    ).toEqual('/zxikHGnHjfY5KF1eksnwFQvqNtQa0bAqDRDJBwPoMNY/dGVzdC5wbmc.png');
-  });
-
   test('Add Extension from format', () => {
     expect(
       pb()
@@ -88,18 +75,21 @@ describe('Chain', () => {
     );
   });
 
-  test('Add Extension fallback', () => {
+  test('Do not Add Extension if plain', () => {
     expect(
-      pb().build({
-        path: 'testwithoutextension',
-        addExtension: true,
-        signature: {
-          key: '73757065722d7365637265742d6b6579', // super-secret-key
-          salt: '73757065722d7365637265742d73616c74', // super-secret-salt
-        },
-      }),
+      pb()
+        .format('webp')
+        .build({
+          path: 'test.png',
+          addExtension: true,
+          plain: true,
+          signature: {
+            key: '73757065722d7365637265742d6b6579', // super-secret-key
+            salt: '73757065722d7365637265742d73616c74', // super-secret-salt
+          },
+        }),
     ).toEqual(
-      '/NZqsjnAakEL_WYW3m0jRJmfzbVojINSNJD_ygU9VzFY/dGVzdHdpdGhvdXRleHRlbnNpb24.testwithoutextension',
+      '/pJaBmZSqwN__JanbIGi_nT57o0sA4YPkhkfn-SKZTEk/f:webp/plain/test.png',
     );
   });
 });

--- a/test/chain.test.ts
+++ b/test/chain.test.ts
@@ -57,4 +57,49 @@ describe('Chain', () => {
       '/8q2Ey2URdWizZb8PgAUKMO6C2tD4aXOa2IbCMV9pTKA/bl:10/-/ar:true/dGVzdC5wbmc',
     );
   });
+
+  test('Add Extension from path', () => {
+    expect(
+      pb().build({
+        path: 'test.png',
+        addExtension: true,
+        signature: {
+          key: '73757065722d7365637265742d6b6579', // super-secret-key
+          salt: '73757065722d7365637265742d73616c74', // super-secret-salt
+        },
+      }),
+    ).toEqual('/zxikHGnHjfY5KF1eksnwFQvqNtQa0bAqDRDJBwPoMNY/dGVzdC5wbmc.png');
+  });
+
+  test('Add Extension from format', () => {
+    expect(
+      pb()
+        .format('webp')
+        .build({
+          path: 'test.png',
+          addExtension: true,
+          signature: {
+            key: '73757065722d7365637265742d6b6579', // super-secret-key
+            salt: '73757065722d7365637265742d73616c74', // super-secret-salt
+          },
+        }),
+    ).toEqual(
+      '/XmZ2pGTP_p5AD6Sk5lOo83-T1BcQVmEcPVymiKZEoF8/f:webp/dGVzdC5wbmc.webp',
+    );
+  });
+
+  test('Add Extension fallback', () => {
+    expect(
+      pb().build({
+        path: 'testwithoutextension',
+        addExtension: true,
+        signature: {
+          key: '73757065722d7365637265742d6b6579', // super-secret-key
+          salt: '73757065722d7365637265742d73616c74', // super-secret-salt
+        },
+      }),
+    ).toEqual(
+      '/NZqsjnAakEL_WYW3m0jRJmfzbVojINSNJD_ygU9VzFY/dGVzdHdpdGhvdXRleHRlbnNpb24.testwithoutextension',
+    );
+  });
 });


### PR DESCRIPTION
ImgProxy supports adding the desired format [at the end of the url](https://github.com/imgproxy/imgproxy/blob/6f292443eafb2e39f9252175b61faa6b38105a7c/docs/generating_the_url.md#extension) instead of or in addition to specifying it with the `f:` flag.

Having the format in the url can be beneficial for some setups, as some proxies cache responses based on this. Cloudflare CDN is one such example. 

This pull requests support adding the extension at the end of the generated url.

It adds the option `BuildOptions.addExtension`. When set to true, the extension will be added. It is NOT a breaking change. just an extra option.

Tests have been added to test the new behavior.

I've also manually tested that the resulting urls do indeed work with the latest version of imgproxy. I didn't find a specific test file for building, so I put it in the Chain tests. If you want, I can refactor that to their own test file.